### PR TITLE
Support VCD Single-Bit Alias Syntax

### DIFF
--- a/Configfile
+++ b/Configfile
@@ -60,6 +60,7 @@ TESTSRC     += syntax-multi_map.bash
 TESTSRC     += syntax-multi_set.bash
 TESTSRC     += syntax-skip_cycle.bash
 TESTSRC     += syntax-skip_many_cycles.bash
+TESTSRC     += syntax-bitwise.bash
 
 # Lists the signals present in a VCD file
 BINARIES    += vcdsigs

--- a/src/libvcd/alias.h++
+++ b/src/libvcd/alias.h++
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014 Howard Mao
+ *   <zhehao.mao@gmail.com>
+ *
+ * This file is part of vcddiff.
+ *
+ * vcddiff is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * vcddiff is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with vcddiff.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "longname.h++"
+#include "option.h++"
+
+#include <string>
+
+#ifndef ALIAS_HXX
+#define ALIAS_HXX
+
+namespace libvcd
+{
+    /* Represents the target of a VCD shortname.
+     * fullname is the longname of the VCD signal
+     * bit is the bit index (little-endian order) in
+     * that signal that the alias refers to */
+    class alias
+    {
+        private:
+            const std::string _fullname;
+            const option<int> _bit;
+
+        public:
+            alias(const std::string &fullname, const option<int> bit)
+                : _fullname(fullname), _bit(bit) {}
+            /* The long name of the signal */
+            std::string fullname(void) { return _fullname; }
+            /* The individual bit in the multi-bit signal that
+             * the short name refers to.
+             * If the option is not valid, the alias refers to
+             * the entire signal. */
+            option<int> bit(void) { return _bit; }
+    };
+}
+
+#endif

--- a/src/libvcd/datum.c++
+++ b/src/libvcd/datum.c++
@@ -32,8 +32,8 @@ datum::datum(void)
 {
 }
 
-datum::datum(const std::string text)
-    : _valid(true),
+datum::datum(const std::string text, bool valid)
+    : _valid(valid),
       _changed(false),
       _text(text)
 {
@@ -45,6 +45,19 @@ datum& datum::operator=(const std::string new_text)
     this->_valid = true;
     this->_text = new_text;
     return *this;
+}
+
+size_t datum::width(void) const
+{
+    if (_text[0] == 'b')
+        return _text.length() - 1;
+    return 1;
+}
+
+void datum::setbit(int pos, char bit)
+{
+    this->_valid = true;
+    this->_text[pos + 1] = bit;
 }
 
 bool libvcd::operator==(const datum &a, const datum &b)

--- a/src/libvcd/datum.h++
+++ b/src/libvcd/datum.h++
@@ -47,8 +47,9 @@ namespace libvcd
         datum(void);
 
         /* Builds a new datum, given some text from a VCD file that
-         * represents the value. */
-        datum(const std::string text);
+         * represents the value and, optionally, a boolean
+         * indicating whether the text should be considered valid */
+        datum(const std::string text, bool valid = true);
 
         /* Accessor functions. */
         const std::string text(void) const { return this->_text; }
@@ -74,6 +75,12 @@ namespace libvcd
         /* Returns TRUE if this values has ever changed, which means
          * it's been set when it's already been valid. */
         bool changed(void) const { return _changed; }
+
+        /* Returns the number of bits in this datum */
+        size_t width(void) const;
+
+        /* Set a bit in this datum */
+        void setbit(int pos, char bit);
     };
 
     bool operator==(const datum &a, const datum &b);

--- a/src/libvcd/option.h++
+++ b/src/libvcd/option.h++
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2014 Howard Mao
+ *   <zhehao.mao@gmail.com>
+ *
+ * This file is part of vcddiff.
+ *
+ * vcddiff is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * vcddiff is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with vcddiff.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPTION_HXX
+#define OPTION_HXX
+
+namespace libvcd {
+    /* represents a value which may or may not exists */
+    template <typename T>
+    class option
+    {
+        private:
+            bool _valid;
+            T _value;
+
+        public:
+            /* create an empty option */
+            option () : _valid(false) {}
+            /* create a valid option with the given value */
+            option (T value) : _valid(true), _value(value) {}
+            /* copy constructor */
+            option (const option<T> &opt) :
+                _valid(opt._valid), _value(opt._value) {}
+            /* true if this option actually holds a value,
+             * false otherwise */
+            bool valid(void) { return _valid; }
+            /* the value contained by this option */
+            T value(void)
+            {
+                if (!_valid) {
+                    fprintf(stderr, "Trying to access invalid option value");
+                    abort();
+                }
+                return _value;
+            }
+    };
+}
+
+#endif

--- a/src/libvcd/vcd.h++
+++ b/src/libvcd/vcd.h++
@@ -24,6 +24,7 @@
 
 #include "datum.h++"
 #include "longname.h++"
+#include "alias.h++"
 #include <map>
 #include <string>
 #include <vector>
@@ -37,7 +38,7 @@ namespace libvcd
         /* This maps a short name to a datum.  This map is used when
          * reading the values from the VCD file, as here the values
          * are tagged with the short name. */
-        std::multimap<const std::string, datum *> _short_name;
+        std::multimap<const std::string, alias *> _short_name;
 
         /* This maps the long name of of an entry to its current
          * value.  The idea here is that we need to be able to compare

--- a/test/vcddiff/syntax-bitwise.bash
+++ b/test/vcddiff/syntax-bitwise.bash
@@ -1,0 +1,49 @@
+#include "harness.bash"
+
+cat >$TMPA <<"EOF"
+$timescale 1ps $end
+$scope module Counter $end
+$var wire 2 N0 count [1:0] $end
+$upscope $end
+$enddefinitions $end
+$dumpvars
+$end
+#0
+b00 N0
+#1
+b01 N0
+#2
+b10 N0
+#3
+b11 N0
+EOF
+
+cat >$TMPB <<"EOF"
+$timescale 1ps $end
+$scope module Counter $end
+$var wire 1 N1 count [1] $end
+$var wire 1 N0 count [0] $end
+$upscope $end
+$enddefinitions $end
+$dumpvars
+$end
+#0
+0N0
+0N1
+#1
+1N0
+0N1
+#2
+0N0
+1N1
+#3
+1N0
+1N1
+EOF
+
+cat >$RETGOLD <<"EOF"
+0
+EOF
+
+cat >$OUTGOLD <<"EOF"
+EOF


### PR DESCRIPTION
VCD has a syntax feature in which a shortname can refer to a single bit inside a multi-bit signal instead of an entire signal. The latest commit adds support for that.
