### PR TITLE
Add timesteps per cycle option and new tests

### DIFF
--- a/Configfile
+++ b/Configfile
@@ -62,6 +62,9 @@ TESTSRC     += syntax-skip_cycle.bash
 TESTSRC     += syntax-skip_many_cycles.bash
 TESTSRC     += syntax-bitwise.bash
 
+TESTSRC     += flags-raising_signals.bash
+TESTSRC     += flags-tspc.bash
+
 # Lists the signals present in a VCD file
 BINARIES    += vcdsigs
 SOURCES     += vcdsigs.c++

--- a/src/libvcd/vcd.c++
+++ b/src/libvcd/vcd.c++
@@ -40,11 +40,12 @@ static bool all_white_p(const char *s);
  * If this is not a bit selection, return an invalid option */
 static option<int> parse_bitsel(const char *sel);
 
-vcd::vcd(const std::string filename, int raise_signals)
+vcd::vcd(const std::string filename, int raise_signals, int tspc)
     : _short_name(),
       _long_name(),
       _file(NULL),
-      _has_more_cycles(false)
+      _has_more_cycles(false),
+      _tspc(tspc)
 {
     _file = fopen(filename.c_str(), "r");
     if (_file == NULL) {
@@ -144,7 +145,7 @@ vcd::vcd(const std::string filename, int raise_signals)
                 abort();
             }
             this->_has_more_cycles = true;
-            this->_cycle = this->_next_cycle - 1;
+            this->_cycle = this->_next_cycle - tspc;
             goto done;
         } else if (str_start(buffer, "$timescale")) {
             needs_end = true;
@@ -193,7 +194,7 @@ void vcd::step(void)
     /* Move to the next cycle, checking to see if the VCD file has
      * skipped a cycle.  If it has skipped a cycle then we simply
      * return here, as that just means nothing has changed at all. */
-    this->_cycle++;
+    this->_cycle += _tspc;
     if (this->_cycle != this->_next_cycle)
         return;
     this->_has_more_cycles = false;

--- a/src/libvcd/vcd.h++
+++ b/src/libvcd/vcd.h++
@@ -62,9 +62,14 @@ namespace libvcd
          * this file, and FALSE otherwise. */
         bool _has_more_cycles;
 
+        /* Number of verilog timesteps in a single clock cycle */
+        int _tspc;
+
     public:
         /* Generates a new VCD file that reads from the given filename. */
-        vcd(const std::string filename, int raise_signals = 0);
+        vcd(const std::string filename,
+                int raise_signals = 0,
+                int tspc = 1);
 
         ~vcd(void);
 

--- a/src/vcddiff.c++
+++ b/src/vcddiff.c++
@@ -60,6 +60,8 @@ void print_usage(FILE *f)
                " signals in file a\n"
                "  --raise-b-signals Number of module levels to raise"
                " signals in file b\n"
+               "  --a-tspc Number of timesteps per cycle in file a\n"
+               "  --b-tspc Number of timesteps per cycle in file b\n"
                "  --version: Print the version number and exit\n"
                "  --help:    Print this help text and exit\n");
 }
@@ -71,9 +73,12 @@ int main(int argc, char *argv[])
         {"help", 0, NULL, 'h'},
         {"raise-a-signals", 1, NULL, 'a'},
         {"raise-b-signals", 1, NULL, 'b'},
+        {"a-tspc", 1, NULL, 'c'},
+        {"b-tspc", 1, NULL, 'd'},
         {NULL, 0, NULL, 0}
     };
     int raise_a_signals = 0, raise_b_signals = 0;
+    int a_tspc = 1, b_tspc = 1;
     int opt;
 
     while ((opt = getopt_long(argc, argv, "", options, NULL)) > 0) {
@@ -90,6 +95,12 @@ int main(int argc, char *argv[])
         case 'b':
             raise_b_signals = atoi(optarg);
             break;
+        case 'c':
+            a_tspc = atoi(optarg);
+            break;
+        case 'd':
+            b_tspc = atoi(optarg);
+            break;
         default:
             print_usage(stderr);
             exit(EXIT_FAILURE);
@@ -105,8 +116,8 @@ int main(int argc, char *argv[])
     b_filename = argv[optind + 1];
 
     /* Open the two files that we were given. */
-    libvcd::vcd a(a_filename, raise_a_signals);
-    libvcd::vcd b(b_filename, raise_b_signals);
+    libvcd::vcd a(a_filename, raise_a_signals, a_tspc);
+    libvcd::vcd b(b_filename, raise_b_signals, b_tspc);
 
     /* Read the given files all the way through. */
     any_failures = false;

--- a/test/vcddiff/flags-raising_signals.bash
+++ b/test/vcddiff/flags-raising_signals.bash
@@ -1,0 +1,50 @@
+#include "harness.bash"
+
+cat >$TMPA <<"EOF"
+$timescale 1ps $end
+$scope module AMod $end
+$scope module Test $end
+$var wire 2 N0 sig $end
+$upscope end
+$upscope end
+$enddefinitions $end
+$dumpvars
+$end
+#0
+b00 N0
+#1
+b01 N0
+#2
+b10 N0
+#3
+b11 N0
+EOF
+
+cat >$TMPB <<"EOF"
+$timescale 1ps $end
+$scope module BMod $end
+$scope module Test $end
+$var wire 2 N0 sig $end
+$upscope end
+$upscope end
+$enddefinitions $end
+$dumpvars
+$end
+#0
+b00 N0
+#1
+b01 N0
+#2
+b10 N0
+#3
+b11 N0
+EOF
+
+echo "--raise-a-signals=1 --raise-b-signals=1" > $ARGS_FILE
+
+cat >$RETGOLD <<"EOF"
+0
+EOF
+
+cat >$OUTGOLD <<"EOF"
+EOF

--- a/test/vcddiff/flags-tspc.bash
+++ b/test/vcddiff/flags-tspc.bash
@@ -1,0 +1,46 @@
+#include "harness.bash"
+
+cat >$TMPA <<"EOF"
+$timescale 1ps $end
+$scope module Test $end
+$var wire 2 N0 sig $end
+$upscope end
+$enddefinitions $end
+$dumpvars
+$end
+#0
+b00 N0
+#3
+b01 N0
+#6
+b10 N0
+#9
+b11 N0
+EOF
+
+cat >$TMPB <<"EOF"
+$timescale 1ps $end
+$scope module Test $end
+$var wire 2 N0 sig $end
+$upscope end
+$enddefinitions $end
+$dumpvars
+$end
+#2
+b00 N0
+#4
+b01 N0
+#6
+b10 N0
+#8
+b11 N0
+EOF
+
+echo "--a-tspc=3 --b-tspc=2" > $ARGS_FILE
+
+cat >$RETGOLD <<"EOF"
+0
+EOF
+
+cat >$OUTGOLD <<"EOF"
+EOF

--- a/test/vcddiff/harness.bash
+++ b/test/vcddiff/harness.bash
@@ -15,15 +15,21 @@ export TMPA="$TMP/a.vcd"
 export TMPB="$TMP/b.vcd"
 export RETGOLD="$TMP/ret.gold"
 export OUTGOLD="$TMP/out.gold"
+export ARGS_FILE="$TMP/args"
+
+# make sure the file exists
+touch $ARGS_FILE
 
 ARCHIVE=`awk '/^__ARCHIVE_BELOW__/ {print NR + 1; exit 0; }' $0`
 tail -n+$ARCHIVE $0 | bash -ex
+
+export TEST_ARGS="$(cat $ARGS_FILE)"
 
 set +e
 
 if [[ "$1" == "--valgrind" ]]
 then
-    valgrind -q $PTEST_BINARY $TMPA $TMPB > $TMP/out 2> $TMP/valgrind
+    valgrind -q $PTEST_BINARY $TEST_ARGS $TMPA $TMPB > $TMP/out 2> $TMP/valgrind
     echo "$?" > $TMP/ret
     
     cat $TMP/valgrind
@@ -32,7 +38,7 @@ then
         exit 1
     fi
 else
-    $PTEST_BINARY $TMPA $TMPB > $TMP/out
+    $PTEST_BINARY $TEST_ARGS $TMPA $TMPB > $TMP/out
     echo "$?" > $TMP/ret
 fi
 


### PR DESCRIPTION
To fix the issue with VCD files that take multiple timesteps for a single cycle, I've added flags --a-tspc and --b-tspc to set timesteps per cycle for each of the VCD files.

I've also added tests for this feature and the earlier signal-raising feature.
